### PR TITLE
[FIX] mail_tracking: Added restriction on email search.

### DIFF
--- a/mail_tracking/views/mail_tracking_email_view.xml
+++ b/mail_tracking/views/mail_tracking_email_view.xml
@@ -99,8 +99,8 @@
                     string="Email"
                     filter_domain="['|', ('sender', 'ilike', self), ('recipient', 'ilike', self)]"
                 />
-            <field name="sender" string="Sender" />
-            <field name="recipient" string="Recipient" />
+            <field name="sender" string="Sender" filter_domain="[('sender', '=', self)]" />
+            <field name="recipient" string="Recipient" filter_domain="[('recipient', '=', self)]" />
             <field name="name" string="Subject" />
             <field name="time" string="Time" />
             <field name="date" string="Date" />


### PR DESCRIPTION
A filter_domain was added in the sender and recipient fields to be able to handle a more specific filter when using mail tracking.