### PR TITLE
[REF] mail_debrand: make configurable remove_parent from mail brand

### DIFF
--- a/mail_debrand/models/mail_mail.py
+++ b/mail_debrand/models/mail_mail.py
@@ -10,6 +10,7 @@ class MailMail(models.AbstractModel):
 
     def _send_prepare_body(self):
         body = super()._send_prepare_body()
+        remove_parent = self._context.get("mail_remove_parent", 0)
         return self.env["mail.render.mixin"].remove_href_odoo(
-            body or "", remove_parent=0, remove_before=1
+            body or "", remove_parent=remove_parent, remove_before=1
         )


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Currently, in v14.0, mail Odoo brand is:

`Sent by YourCompany using Odoo.`

By default is removing` using Odoo` but you can use parameter `remove_parent` it in order to remove `Sent by YourCompany`, too, but that parameter is not configurable or inheritable, so MR makes configurable parameter `remove_parent` using context.

Current behavior before PR:
There is not option to configure parameter `remove_parent` and use default value.

Desired behavior after PR is merged:
Option to configurate parameter `remove_parent` available.

-- I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
