### PR TITLE
[FIX] mail_tracking: compute recipient_address considering more cases

### DIFF
--- a/mail_tracking/migrations/14.0.2.0.1/post-migration.py
+++ b/mail_tracking/migrations/14.0.2.0.1/post-migration.py
@@ -1,0 +1,14 @@
+from odoo import SUPERUSER_ID, api
+
+
+def migrate(cr, version):
+    fix_recipient_address_mail_tracking(cr)
+
+
+def fix_recipient_address_mail_tracking(cr):
+    """TODO: add docstring"""
+    env = api.Environment(cr, SUPERUSER_ID, {})
+    emails_to_fix = env["mail.tracking.email"].search(
+        [("recipient_address", "=", False)]
+    )
+    emails_to_fix._compute_recipient_address()

--- a/mail_tracking/models/mail_tracking_email.py
+++ b/mail_tracking/models/mail_tracking_email.py
@@ -9,7 +9,6 @@ import uuid
 from datetime import datetime
 
 from odoo import api, fields, models, tools
-from odoo.tools import email_split
 
 _logger = logging.getLogger(__name__)
 
@@ -204,10 +203,15 @@ class MailTrackingEmail(models.Model):
     @api.depends("recipient")
     def _compute_recipient_address(self):
         for email in self:
-            email.recipient_address = False
-            recipient_email = email_split(email.recipient)
-            if recipient_email:
-                email.recipient_address = recipient_email[0].lower()
+            is_empty_recipient = not email.recipient or "<@False>" in email.recipient
+            if not is_empty_recipient:
+                matches = re.search(r"<(.*@.*)>", email.recipient)
+                if matches:
+                    email.recipient_address = matches.group(1).lower()
+                else:
+                    email.recipient_address = email.recipient.lower()
+            else:
+                email.recipient_address = False
 
     @api.depends("name", "recipient")
     def _compute_tracking_display_name(self):

--- a/mail_tracking/views/mail_tracking_email_view.xml
+++ b/mail_tracking/views/mail_tracking_email_view.xml
@@ -105,9 +105,9 @@
                     filter_domain="[('sender', '=', self)]"
                 />
             <field
-                    name="recipient"
-                    string="Recipient"
-                    filter_domain="[('recipient', '=', self)]"
+                    name="recipient_address"
+                    string="Recipient Address"
+                    filter_domain="[('recipient_address', '=', self)]"
                 />
             <field name="name" string="Subject" />
             <field name="time" string="Time" />

--- a/mail_tracking/views/res_partner_view.xml
+++ b/mail_tracking/views/res_partner_view.xml
@@ -12,8 +12,8 @@
         <div name="button_box" position="inside">
             <button
                     name="%(mail_tracking.action_view_mail_tracking_email)d"
-                    context="{'search_default_recipient': email,
-                              'default_recipient': email}"
+                    context="{'search_default_recipient_address': email,
+                              'default_recipient_address': email}"
                     type="action"
                     class="oe_stat_button"
                     icon="fa-envelope-o"


### PR DESCRIPTION
The mail_tracking in v13 is searching the emails as follows:

https://github.com/OCA/social/blob/78daea28e5763cb132c77fcc986408680dd4e84f/mail_tracking/models/mail_tracking_email.py#L203-L214

It's using a regex to catch cases when the recipient is <(emailexample@.example.com)>
and if regex is not matched, it's using the email like comes in the record,
but in v14.0 is using the function email_split
and it's only considering when exactly matching
and excluding the emails as <(emailexample@.example.com)>

https://github.com/OCA/social/blob/147eda96a56c199602c619b5bac3a9911605e918/mail_tracking/models/mail_tracking_email.py#L204-L210

This commit fixes the compute method as v13 and add a migration script
to fix all emails computed incorrectly.

Also, we are using the field recipient_address in filter of search view
of mail.tracking.email in order to use the same field used in computed
method:

https://github.com/OCA/social/blob/147eda96a56c199602c619b5bac3a9911605e918/mail_tracking/models/res_partner.py#L27

And finally, we are updating the validation `<False>`  by `<@False>`,
due to method in v14.0 is returning that when email is False or empty:

https://github.com/odoo/odoo/blob/5358ec76ce0cc99b128451188c958a21d6630d08/odoo/tools/mail.py#L574-L615

`PATCH USE`